### PR TITLE
Admin dash auth

### DIFF
--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -27,12 +27,12 @@ class Permission
 
   def platform_admin_permissions
     return true unless controller == "admin/dashboards" && action.in?(
-    %w(new create))
+      %w(new create))
   end
 
   def campaign_manager_permissions
     return true unless controller == "admin/dashboards" && action.in?(
-    %w(show update))
+      %w(show update))
   end
 
   def registered_user_permissions

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -26,11 +26,13 @@ class Permission
   end
 
   def platform_admin_permissions
-    return true unless controller == "admin/dashboards" && action.in?(%w(new create))
+    return true unless controller == "admin/dashboards" && action.in?(
+    %w(new create))
   end
 
   def campaign_manager_permissions
-    return true unless controller == "admin/dashboards" && action.in?(%w(show update))
+    return true unless controller == "admin/dashboards" && action.in?(
+    %w(show update))
   end
 
   def registered_user_permissions

--- a/app/services/permission.rb
+++ b/app/services/permission.rb
@@ -26,11 +26,11 @@ class Permission
   end
 
   def platform_admin_permissions
-    true
+    return true unless controller == "admin/dashboards" && action.in?(%w(new create))
   end
 
   def campaign_manager_permissions
-    true
+    return true unless controller == "admin/dashboards" && action.in?(%w(show update))
   end
 
   def registered_user_permissions

--- a/spec/features/can_see_admin_dash_spec.rb
+++ b/spec/features/can_see_admin_dash_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+feature "a logged in user" do
+  scenario "can see admin dashboard if platform admin" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: admin.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/show"
+    expect(current_path).to eq("/admin/dashboards/show")
+  end
+
+  scenario "can not see admin dashboard if campaign manager" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: manager.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/show"
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario "can not see admin dashboard if registered user" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: user.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/show"
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario "can see new manager form if campaign manager" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: manager.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/new"
+    expect(current_path).to eq("/admin/dashboards/new")
+  end
+
+  scenario "can not see new manager form if platform admin" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: admin.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/new"
+    expect(current_path).to eq(root_path)
+  end
+
+  scenario "can not see new manager form if registered user" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: user.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/new"
+    expect(current_path).to eq(root_path)
+  end
+end

--- a/spec/features/can_see_new_campaign_manager_form_spec.rb
+++ b/spec/features/can_see_new_campaign_manager_form_spec.rb
@@ -1,25 +1,7 @@
 require "rails_helper"
 
-feature "Admin dashboard is visible" do
-  scenario "to a platform admin" do
-    test_setup
-
-    visit root_path
-
-    within("#login-button") do
-      click_link "Login"
-    end
-    expect(current_path).to eq(login_path)
-
-    fill_in "Username", with: admin.username
-    fill_in "Password", with: "password"
-    click_button "Login"
-
-    visit "/admin/dashboards/show"
-    expect(current_path).to eq("/admin/dashboards/show")
-  end
-
-  scenario "not to a campaign manager" do
+feature "New campaign manager form is visible" do
+  scenario "to a campaign manager" do
     test_setup
 
     visit root_path
@@ -33,7 +15,25 @@ feature "Admin dashboard is visible" do
     fill_in "Password", with: "password"
     click_button "Login"
 
-    visit "/admin/dashboards/show"
+    visit "/admin/dashboards/new"
+    expect(current_path).to eq("/admin/dashboards/new")
+  end
+
+  scenario "not to a platform admin" do
+    test_setup
+
+    visit root_path
+
+    within("#login-button") do
+      click_link "Login"
+    end
+    expect(current_path).to eq(login_path)
+
+    fill_in "Username", with: admin.username
+    fill_in "Password", with: "password"
+    click_button "Login"
+
+    visit "/admin/dashboards/new"
     expect(current_path).to eq(root_path)
   end
 
@@ -51,7 +51,7 @@ feature "Admin dashboard is visible" do
     fill_in "Password", with: "password"
     click_button "Login"
 
-    visit "/admin/dashboards/show"
+    visit "/admin/dashboards/new"
     expect(current_path).to eq(root_path)
   end
 end


### PR DESCRIPTION
Changed permissions for campaign managers and platform admins. Campaign managers can only add new campaign managers, and platform admins can only approve or deny requests to become campaign managers. Tests are written and passing.